### PR TITLE
Auto-release on VERSION bump in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,45 @@ jobs:
           docker run --rm -v $(pwd):/workspace ai-cpp-course:ci \
             bash -c "cd /workspace && pip3 install pytest numpy -q && \
               python3 tests/validate_evidence.py"
+
+  tag-and-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    needs: [docker-build-and-test]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read VERSION and check if tag exists
+        id: check
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists, skipping release"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag v$VERSION does not exist, will create release"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag and release
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          git tag "v${{ steps.check.outputs.version }}"
+          git push origin "v${{ steps.check.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ steps.check.outputs.version }}"
+          generate_release_notes: true
+          name: "v${{ steps.check.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,9 @@ on:
       - "v*"
 
 jobs:
-  release:
+  docker-release:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v4
@@ -29,14 +28,6 @@ jobs:
             echo "ERROR: Tag version ($TAG_VERSION) does not match VERSION file ($FILE_VERSION)"
             exit 1
           fi
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          name: "v${{ steps.version.outputs.version }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
## Summary
- Added `tag-and-release` job to CI workflow that runs after tests pass on main
- Automatically creates a git tag and GitHub release when VERSION file changes
- Ensures version and release are always aligned - just bump VERSION and push to main
- Release.yml now only handles Docker image build (triggered by the tag CI creates)

## Flow
1. Developer bumps VERSION file and pushes to main
2. CI runs lint, version-check, docker-build-and-test
3. If all pass, `tag-and-release` checks if tag exists for current VERSION
4. If not, creates tag `vX.Y.Z` and GitHub release with auto-generated notes
5. Tag push triggers release.yml which builds the Docker image

## Test plan
- [ ] CI passes
- [ ] Merging to main with a new VERSION creates a release automatically