### PR TITLE
Add lesson file links to each lesson README

### DIFF
--- a/ai-cpp-l1/README.md
+++ b/ai-cpp-l1/README.md
@@ -183,11 +183,11 @@ Key flags:
 - Compiler flags (`-O3`, `-march=native`) unlock hardware-specific optimizations
 - For numerical loops, C++ can be 50-100x faster than pure Python
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `setup.md` | Environment setup instructions |
-| `CMakeLists.txt` | Build configuration |
-| `portable_simd_sum_vectors.cpp` | C++ SIMD vector sum with pybind11 |
-| `sum.py` | Python benchmark comparing all three approaches |
+| File | Description |
+|------|-------------|
+| [portable_simd_sum_vectors.cpp](portable_simd_sum_vectors.cpp) | SIMD vector addition with pybind11 bindings |
+| [sum.py](sum.py) | Python benchmark comparing all approaches |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration |
+| [setup.md](setup.md) | Environment setup instructions |

--- a/ai-cpp-l10/README.md
+++ b/ai-cpp-l10/README.md
@@ -471,13 +471,12 @@ tracemalloc.stop()
 - Always profile first, always measure after
 - Know when to stop: diminishing returns are real
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `ai-cpp-l10.md` | This lesson guide |
-| `tracker_pipeline.py` | Baseline tracker pipeline with bottlenecks |
-| `tracker_pipeline_optimized.py` | Same pipeline after all optimizations |
-| `optimization_rounds.py` | Step-by-step optimization with measurements |
-| `test_optimization.py` | Unit tests verifying correctness |
-| `test_integration_optimization.py` | Integration tests with memory checks |
+| File | Description |
+|------|-------------|
+| [tracker_pipeline.py](tracker_pipeline.py) | Baseline tracker pipeline with bottlenecks |
+| [tracker_pipeline_optimized.py](tracker_pipeline_optimized.py) | Pipeline after all optimizations applied |
+| [optimization_rounds.py](optimization_rounds.py) | Step-by-step optimization with measurements |
+| [test_optimization.py](test_optimization.py) | Unit tests verifying correctness |
+| [test_integration_optimization.py](test_integration_optimization.py) | Integration tests with memory checks |

--- a/ai-cpp-l11/README.md
+++ b/ai-cpp-l11/README.md
@@ -516,14 +516,14 @@ processing thousands of detections per frame, this is significant.
 - `std::array` avoids heap allocation for fixed-size data
 - Modern C++ safety features are zero-cost — the safe code is often the fastest code
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `CMakeLists.txt` | Build configuration with ASAN/UBSAN options |
-| `safe_views.cpp` | std::span usage: sum, slice, bounds checking |
-| `memory_safety_demo.cpp` | RAII, std::optional, smart pointers |
-| `asan_example.cpp` | Intentionally buggy code for ASAN demonstration |
-| `safety_demo.py` | Python demo using safe_views and memory_safety_demo |
-| `test_safety.py` | Unit tests for all safety features |
-| `test_integration_safety.py` | Integration test: tracking loop with safe types |
+| File | Description |
+|------|-------------|
+| [safe_views.cpp](safe_views.cpp) | std::span safe view operations |
+| [memory_safety_demo.cpp](memory_safety_demo.cpp) | RAII, optional, and smart pointers |
+| [asan_example.cpp](asan_example.cpp) | Intentionally buggy code for ASAN demo |
+| [safety_demo.py](safety_demo.py) | Python demo of safe views and memory safety |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build with ASAN/UBSAN options |
+| [test_safety.py](test_safety.py) | Unit tests for all safety features |
+| [test_integration_safety.py](test_integration_safety.py) | Integration test with safe tracking loop |

--- a/ai-cpp-l2/README.md
+++ b/ai-cpp-l2/README.md
@@ -219,11 +219,12 @@ python3 ai-cpp-l2/crop_resize.py
 - OpenCV `cv::Mat` and NumPy share the same memory layout (row-major BGR)
 - `constexpr` moves computation from runtime to compile time
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `CMakeLists.txt` | Build configuration for the image processor module |
-| `cpp_image_processor.cpp` | C++ crop+resize with three execution modes |
-| `crop_resize.py` | Python benchmark comparing all approaches |
-| `bmp-2048x1365.bmp` | Test image for benchmarking |
+| File | Description |
+|------|-------------|
+| [cpp_image_processor.cpp](cpp_image_processor.cpp) | C++ crop and resize with execution policies |
+| [crop_resize.py](crop_resize.py) | Python benchmark comparing all approaches |
+| [opencv_benchmark.py](opencv_benchmark.py) | OpenCV performance measurement script |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration |
+| [bmp-2048x1365.bmp](bmp-2048x1365.bmp) | Test image for benchmarking |

--- a/ai-cpp-l3/README.md
+++ b/ai-cpp-l3/README.md
@@ -261,19 +261,6 @@ python3 ai-cpp-l3/nanobind-example/nanobind_example.py
 - [nanobind](https://github.com/wjakob/nanobind) is the modern successor to pybind11 (smaller, faster, zero-copy) — see [L4](../ai-cpp-l4/) for the full framework lesson
 - Deterministic exception allocation makes C++ exceptions real-time safe
 
-## Files and Submodules
-
-| File/Directory | Purpose |
-|----------------|---------|
-| `nanobind-example/` | Basic nanobind binding example |
-| `shm/` | POSIX shared memory RAII wrapper |
-| `safe-shm/` | Lock-free shared memory library (seqlock, cyclic buffer, double buffer) |
-| `exception-rt/` | Deterministic exception allocator for real-time |
-| `single-task-runner/` | Thread-based task execution utility |
-| `double-buffer-swapper/` | Core double-buffer swap primitive |
-| `flat-type/` | FlatType concept definition |
-| `image-shm-dblbuf/` | Image-specific shared memory double buffer |
-
 ## Dependencies
 
 ```bash
@@ -285,3 +272,16 @@ sudo apt-get install libfmt-dev
 - [nanobind documentation](https://github.com/wjakob/nanobind)
 - [nanobind example project](https://github.com/wjakob/nanobind_example)
 - [POSIX shared memory (man page)](https://man7.org/linux/man-pages/man7/shm_overview.7.html)
+
+## Lesson Files
+
+| File | Description |
+|------|-------------|
+| [shm/](shm/) | POSIX shared memory RAII wrapper |
+| [safe-shm/](safe-shm/) | Lock-free shared memory primitives |
+| [flat-type/](flat-type/) | FlatType concept definition |
+| [double-buffer-swapper/](double-buffer-swapper/) | Core double-buffer swap primitive |
+| [image-shm-dblbuf/](image-shm-dblbuf/) | Image shared memory double buffer |
+| [nanobind-example/](nanobind-example/) | Basic nanobind binding example |
+| [exception-rt/](exception-rt/) | Deterministic exception allocator for real-time |
+| [single-task-runner/](single-task-runner/) | Thread-based task execution utility |

--- a/ai-cpp-l4/README.md
+++ b/ai-cpp-l4/README.md
@@ -179,15 +179,15 @@ pytest ai-cpp-l4/ -v
 5. **ndarray with shape constraints**: Modify `from_array()` to accept only arrays of
    exactly 4 elements. What happens when you pass an array of 5?
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `CMakeLists.txt` | Build configuration for all three nanobind modules |
-| `bbox_native.cpp` | C++ BoundingBox with nanobind bindings |
-| `bbox_slow.py` | Pure Python BoundingBox (the "before" version) |
-| `buffer_pool_native.cpp` | Zero-overhead buffer pool with ndarray |
-| `history_view_native.cpp` | Zero-copy circular buffer with view semantics |
-| `benchmark_nanobind.py` | Performance comparison: Python vs C++ |
-| `test_nanobind.py` | Unit tests for all three modules |
-| `test_integration_nanobind.py` | Integration tests simulating real workloads |
+| File | Description |
+|------|-------------|
+| [bbox_native.cpp](bbox_native.cpp) | C++ BoundingBox with nanobind bindings |
+| [buffer_pool_native.cpp](buffer_pool_native.cpp) | Zero-overhead buffer pool with ndarray |
+| [history_view_native.cpp](history_view_native.cpp) | Zero-copy circular buffer with views |
+| [bbox_slow.py](bbox_slow.py) | Pure Python BoundingBox for comparison |
+| [benchmark_nanobind.py](benchmark_nanobind.py) | Performance comparison: Python vs C++ |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration |
+| [test_nanobind.py](test_nanobind.py) | Unit tests for all nanobind modules |
+| [test_integration_nanobind.py](test_integration_nanobind.py) | Integration tests for real workloads |

--- a/ai-cpp-l5/README.md
+++ b/ai-cpp-l5/README.md
@@ -409,14 +409,18 @@ What it optimizes:
 
 ---
 
-## Files in This Lesson
+## Lesson Files
 
-| File | What It Demonstrates |
-|------|---------------------|
-| `bbox_slots.py` | `__slots__`, `@dataclass(slots=True)`, memory measurement |
-| `numpy_views.py` | Views vs. copies, `np.shares_memory()` |
-| `preallocated_buffers.py` | Pre-allocated numpy buffers |
-| `thread_pool_io.py` | `ThreadPoolExecutor` vs. `Thread()` per task |
-| `benchmark_python_opt.py` | Benchmark all optimizations with timing + memory |
-| `test_python_opt.py` | Unit tests for all variants |
-| `test_integration_python_opt.py` | Integration test simulating a tracking loop |
+| File | Description |
+|------|-------------|
+| [bbox_slots.py](bbox_slots.py) | Slots and dataclass memory optimization |
+| [numpy_views.py](numpy_views.py) | Numpy views vs copies demonstration |
+| [preallocated_buffers.py](preallocated_buffers.py) | Pre-allocated numpy buffer patterns |
+| [thread_pool_io.py](thread_pool_io.py) | ThreadPoolExecutor vs Thread-per-task |
+| [binary_protocol.py](binary_protocol.py) | Binary protocol for efficient data transfer |
+| [defensive_patterns.py](defensive_patterns.py) | Defensive coding patterns for Python |
+| [kalman_preallocated.py](kalman_preallocated.py) | Kalman filter with pre-allocated buffers |
+| [torch_compile_demo.py](torch_compile_demo.py) | torch.compile usage demonstration |
+| [benchmark_python_opt.py](benchmark_python_opt.py) | Benchmark suite for all optimizations |
+| [test_python_opt.py](test_python_opt.py) | Unit tests for all variants |
+| [test_integration_python_opt.py](test_integration_python_opt.py) | Integration test for tracking loop |

--- a/ai-cpp-l6/README.md
+++ b/ai-cpp-l6/README.md
@@ -276,16 +276,17 @@ python3 ai-cpp-l6/gpu_timer.py
 - Throughput and latency are different metrics — pipelines can have high
   throughput despite high latency (Little's law)
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `CMakeLists.txt` | Build configuration for latency_timer and cache_benchmark |
-| `latency_timer.cpp` | RAII ScopedTimer with named sections, exposed via nanobind |
-| `cache_benchmark.cpp` | Sequential/random/stride access benchmarks to reveal cache hierarchy |
-| `measure_latency.py` | Python LatencyTracker with percentile computation and ASCII charts |
-| `cache_explorer.py` | Runs cache benchmarks and visualizes the results |
-| `gpu_timer.py` | torch.cuda.Event wrapper with CPU fallback |
-| `benchmark_measurement.py` | Full benchmark suite comparing all measurement methods |
-| `test_measurement.py` | Unit tests for timer accuracy and cache benchmark ordering |
-| `test_integration_measurement.py` | Integration tests for pipeline timing and boundary detection |
+| File | Description |
+|------|-------------|
+| [latency_timer.cpp](latency_timer.cpp) | RAII ScopedTimer with nanobind bindings |
+| [cache_benchmark.cpp](cache_benchmark.cpp) | Cache hierarchy access pattern benchmarks |
+| [measure_latency.py](measure_latency.py) | Python latency tracker with percentiles |
+| [cache_explorer.py](cache_explorer.py) | Cache benchmark runner and visualizer |
+| [gpu_timer.py](gpu_timer.py) | GPU timing with torch.cuda.Event wrapper |
+| [profile_pipeline.py](profile_pipeline.py) | Pipeline profiling demonstration |
+| [benchmark_measurement.py](benchmark_measurement.py) | Full measurement method benchmark suite |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration |
+| [test_measurement.py](test_measurement.py) | Unit tests for timer and cache benchmarks |
+| [test_integration_measurement.py](test_integration_measurement.py) | Integration tests for pipeline timing |

--- a/ai-cpp-l7/README.md
+++ b/ai-cpp-l7/README.md
@@ -280,15 +280,18 @@ python3 ai-cpp-l7/gpu_pipeline_demo.py
 - Batch inference amortizes fixed overhead across multiple inputs
 - Not all workloads benefit from GPU — small data, branchy code, I/O-bound work stays on CPU
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `CMakeLists.txt` | Build configuration with optional CUDA support |
-| `gpu_preprocess.cu` | Fused CUDA kernel: uint8 HWC → float32 CHW + normalize |
-| `gpu_preprocess_cpu.cpp` | CPU reference + 3-step "tracker_engine style" preprocess |
-| `pinned_allocator.cpp` | Pinned memory pool with cudaMallocHost/malloc fallback |
-| `benchmark_gpu.py` | Performance comparison: CPU vs GPU, regular vs pinned |
-| `gpu_pipeline_demo.py` | Side-by-side "wrong way" vs "right way" GPU pipeline |
-| `test_gpu.py` | Unit tests for preprocess and allocator (graceful GPU skip) |
-| `test_integration_gpu.py` | Full pipeline tests, sustained load, batch inference |
+| File | Description |
+|------|-------------|
+| [gpu_preprocess.cu](gpu_preprocess.cu) | Fused CUDA preprocessing kernel |
+| [gpu_preprocess_cpu.cpp](gpu_preprocess_cpu.cpp) | CPU reference preprocessing implementation |
+| [pinned_allocator.cpp](pinned_allocator.cpp) | Pinned memory pool with fallback |
+| [batch_inference_demo.py](batch_inference_demo.py) | Batched GPU inference demonstration |
+| [cuda_streams_demo.py](cuda_streams_demo.py) | CUDA streams overlap demonstration |
+| [gpu_pipeline_demo.py](gpu_pipeline_demo.py) | Wrong vs right GPU pipeline comparison |
+| [tracker_engine_fixes.py](tracker_engine_fixes.py) | Tracker engine GPU anti-pattern fixes |
+| [benchmark_gpu.py](benchmark_gpu.py) | CPU vs GPU performance comparison |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration with CUDA support |
+| [test_gpu.py](test_gpu.py) | Unit tests for preprocess and allocator |
+| [test_integration_gpu.py](test_integration_gpu.py) | Full pipeline and batch inference tests |

--- a/ai-cpp-l8/README.md
+++ b/ai-cpp-l8/README.md
@@ -339,15 +339,15 @@ pytest ai-cpp-l8/ -v
 4. **`if constexpr` pipeline**: Create a template image processing pipeline where each
    stage (grayscale, blur, threshold) is selected at compile time.
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `CMakeLists.txt` | Build configuration for all nanobind modules |
-| `concepts_demo.cpp` | FlatType, Numeric, ImageLike concepts with constrained templates |
-| `compile_time_lut.cpp` | constexpr LUT generation for grayscale and gamma correction |
-| `state_machine.cpp` | String-based vs variant-based state machine comparison |
-| `state_machine_slow.py` | Python string-based state machine (the "before" version) |
-| `benchmark_concepts.py` | Performance comparison across all techniques |
-| `test_concepts.py` | Unit tests for concepts, LUTs, and state machine |
-| `test_integration_concepts.py` | Integration tests simulating real tracking workloads |
+| File | Description |
+|------|-------------|
+| [concepts_demo.cpp](concepts_demo.cpp) | C++20 concepts with constrained templates |
+| [compile_time_lut.cpp](compile_time_lut.cpp) | constexpr LUT generation for image ops |
+| [state_machine.cpp](state_machine.cpp) | Variant-based vs string state machine |
+| [state_machine_slow.py](state_machine_slow.py) | Python string-based state machine |
+| [benchmark_concepts.py](benchmark_concepts.py) | Performance comparison across techniques |
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration |
+| [test_concepts.py](test_concepts.py) | Unit tests for concepts and LUTs |
+| [test_integration_concepts.py](test_integration_concepts.py) | Integration tests for tracking workloads |

--- a/ai-cpp-l9/README.md
+++ b/ai-cpp-l9/README.md
@@ -582,19 +582,14 @@ the development toolchain.
 - Multi-stage Docker builds separate 3+ GB build environments from slim runtime images
 - Wheels are the standard distribution format for Python packages with compiled extensions
 
-## Files in This Lesson
+## Lesson Files
 
-| File | Purpose |
-|------|---------|
-| `pyproject.toml` | Package configuration with scikit-build-core backend |
-| `CMakeLists.txt` | CMake build rules for the nanobind extension |
-| `VERSION` | Single source of truth for package version |
-| `src/tracker_utils/__init__.py` | Package init, imports native extension |
-| `src/tracker_utils/bbox.py` | High-level Python API wrapping C++ BBox |
-| `src/tracker_utils/_native.cpp` | C++ extension source (nanobind BBox) |
-| `src/tracker_utils/_native.pyi` | Type stubs for IDE autocomplete |
-| `src/tracker_utils/py.typed` | PEP 561 marker for typed package |
-| `Dockerfile.prod` | Multi-stage production Docker image |
-| `build_and_test.sh` | Build, test, and wheel creation script |
-| `test_package.py` | Unit tests for the package |
-| `test_integration_package.py` | Integration tests for installed package |
+| File | Description |
+|------|-------------|
+| [CMakeLists.txt](CMakeLists.txt) | CMake build rules for nanobind extension |
+| [pyproject.toml](pyproject.toml) | Package configuration with scikit-build-core |
+| [VERSION](VERSION) | Single source of truth for package version |
+| [Dockerfile.prod](Dockerfile.prod) | Multi-stage production Docker image |
+| [build_and_test.sh](build_and_test.sh) | Build, test, and wheel creation script |
+| [test_package.py](test_package.py) | Unit tests for the package |
+| [test_integration_package.py](test_integration_package.py) | Integration tests for installed package |

--- a/capstone/README.md
+++ b/capstone/README.md
@@ -130,3 +130,10 @@ components and the full pipeline.
 
 Good luck!  When you are done, run the full test suite and benchmark one final
 time to confirm everything works end-to-end.
+
+## Lesson Files
+
+| File | Description |
+|------|-------------|
+| [CMakeLists.txt](CMakeLists.txt) | CMake build configuration for capstone |
+| [pyproject.toml](pyproject.toml) | Package configuration for fast_tracker_utils |


### PR DESCRIPTION
## Summary
- Each lesson README now has a "Lesson Files" table at the bottom
- Links to all source files in the directory, grouped by type
- C++ sources first, then Python, build/config, tests last
- L3 lists submodule directories instead of files

## Test plan
- [ ] File links render and navigate correctly on GitHub