### PR TITLE
Add Docker layer caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,30 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-buildx-${{ hashFiles('Dockerfile') }}
+          restore-keys: |
+            docker-buildx-
+
       - name: Build Docker image
-        run: docker build -t ai-cpp-course:ci .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ai-cpp-course:ci
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Run Python-only tests inside Docker
         run: |


### PR DESCRIPTION
## Summary
- Switched to `docker/build-push-action` with BuildKit for Docker builds
- Added `actions/cache` for Docker layer caching keyed on Dockerfile hash
- First run still takes full time, but subsequent runs reuse cached layers
- The biggest win: GCC 14 compilation (~20 min) is cached across runs when Dockerfile is unchanged

## How it works
- Cache key: `docker-buildx-{hash of Dockerfile}`
- Fallback: `docker-buildx-` prefix match (partial cache hit)
- Uses `mode=max` to cache all layers, not just final