### PR TITLE
Add CUDA and PyTorch to Docker for GPU testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+# Use NVIDIA CUDA base for GPU support (compatible with --gpus all)
+# Falls back gracefully to CPU-only when run without --gpus
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
@@ -20,6 +22,10 @@ RUN apt-get update && \
 RUN pip3 install meson ninja numpy opencv-python pyudev termcolor scipy pyulog pymavlink asyncio pydantic \
     pybind11 colcon-core colcon-common-extensions setuptools==58.2.0 empy==3.3.4 \
     pytest nanobind \
+    && rm -rf /root/.cache/pip
+
+# Install PyTorch with CUDA support (for GPU benchmarks and tests)
+RUN pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu124 \
     && rm -rf /root/.cache/pip
 
 RUN echo "alias ll='ls -l'" >> ~/.bashrc \

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Everything runs inside Docker -- no environment pollution.
 # Build the development image
 docker build -t ai-cpp-course -f Dockerfile .
 
-# Run the container
+# Run the container (CPU only)
 docker run -it -v $(pwd):/workspace ai-cpp-course
+
+# Run with GPU support (requires nvidia-container-toolkit)
+docker run -it --gpus all -v $(pwd):/workspace ai-cpp-course
 
 # Inside the container: build all lessons
 cd /workspace


### PR DESCRIPTION
## Summary
- Base image changed to `nvidia/cuda:12.4.1-devel-ubuntu22.04`
- Added PyTorch with CUDA 12.4 (`torch torchvision --index-url cu124`)
- Local GPU testing: `docker run --gpus all -v $(pwd):/workspace ai-cpp-course`
- CI continues working without GPU (tests skip gracefully)
- README updated with GPU run instructions

## Test plan
- [ ] Docker builds successfully
- [ ] `docker run --gpus all` exposes GPU to container
- [ ] L7 GPU tests and benchmarks run with actual GPU
- [ ] CI still passes (GPU tests skip)