### PR TITLE
Fix CUDA IPC demos, add Dockerfile.gpu, update benchmarks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Use NVIDIA CUDA base for GPU support (compatible with --gpus all)
-# Falls back gracefully to CPU-only when run without --gpus
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
@@ -22,10 +20,6 @@ RUN apt-get update && \
 RUN pip3 install meson ninja numpy opencv-python pyudev termcolor scipy pyulog pymavlink asyncio pydantic \
     pybind11 colcon-core colcon-common-extensions setuptools==58.2.0 empy==3.3.4 \
     pytest nanobind \
-    && rm -rf /root/.cache/pip
-
-# Install PyTorch with CUDA support (for GPU benchmarks and tests)
-RUN pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu124 \
     && rm -rf /root/.cache/pip
 
 RUN echo "alias ll='ls -l'" >> ~/.bashrc \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,28 @@
+# GPU-enabled image for local testing with NVIDIA GPUs.
+# Extends the base image with CUDA toolkit and PyTorch.
+#
+# Build:
+#   docker build -t ai-cpp-course -f Dockerfile .
+#   docker build -t ai-cpp-course:gpu -f Dockerfile.gpu .
+#
+# Run:
+#   docker run -it --gpus all -v $(pwd):/workspace ai-cpp-course:gpu
+
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS cuda-base
+
+# Copy everything from the base ai-cpp-course image
+FROM ai-cpp-course:latest AS base
+
+# Bring in CUDA toolkit from nvidia image
+COPY --from=cuda-base /usr/local/cuda /usr/local/cuda
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Install PyTorch with CUDA support
+RUN pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu124 \
+    && rm -rf /root/.cache/pip
+
+WORKDIR /workspace
+CMD [ "bash" ]

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Everything runs inside Docker -- no environment pollution.
 # Build the development image
 docker build -t ai-cpp-course -f Dockerfile .
 
-# Run the container (CPU only)
+# Run the container
 docker run -it -v $(pwd):/workspace ai-cpp-course
 
-# Run with GPU support (requires nvidia-container-toolkit)
-docker run -it --gpus all -v $(pwd):/workspace ai-cpp-course
+# For GPU lessons (L7): build and run the GPU image
+docker build -t ai-cpp-course:gpu -f Dockerfile.gpu .
+docker run -it --gpus all -v $(pwd):/workspace ai-cpp-course:gpu
 
 # Inside the container: build all lessons
 cd /workspace

--- a/ai-cpp-l7/README.md
+++ b/ai-cpp-l7/README.md
@@ -324,13 +324,15 @@ Process A (GPU) → IPC handle → Process B (GPU)
 
 ### Performance: IPC vs CPU Round-Trip
 
+Measured on NVIDIA GeForce RTX 3060 Laptop GPU:
+
 | Data size | CUDA IPC | Pinned D2H+H2D | Pageable D2H+H2D |
 |-----------|----------|-----------------|-------------------|
-| 4 MB  | ~0.01 ms | ~0.5 ms | ~1.0 ms |
-| 16 MB | ~0.01 ms | ~2.0 ms | ~3.8 ms |
-| 64 MB | ~0.01 ms | ~7.6 ms | ~14.9 ms |
+| 4 MB  | 0.07 ms | 1.86 ms | 1.01 ms |
+| 16 MB | ~0.07 ms | 7.13 ms | 4.32 ms |
+| 64 MB | ~0.07 ms | 33.56 ms | 31.07 ms |
 
-CUDA IPC is effectively free — once the handle is opened, the pointer works like any device pointer. The 64MB case (a 4K RGB frame) shows a **760x speedup** over pinned copies.
+CUDA IPC is effectively free — once the handle is opened, the pointer works like any device pointer. For 4MB the IPC demo measured a **15x speedup** over the copy-through-CPU path. For larger data the gap widens further since IPC cost stays constant.
 
 ### When to Use CUDA IPC
 

--- a/ai-cpp-l7/cuda_ipc_consumer.cu
+++ b/ai-cpp-l7/cuda_ipc_consumer.cu
@@ -34,13 +34,13 @@ struct IpcHandles {
 };
 
 // Kernel: sum reduction (for verification)
-__global__ void partial_sum(const float* data, double* result, int n)
+__global__ void partial_sum(const float* data, float* result, int n)
 {
-    __shared__ double sdata[256];
+    __shared__ float sdata[256];
     int tid = threadIdx.x;
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    sdata[tid] = (idx < n) ? static_cast<double>(data[idx]) : 0.0;
+    sdata[tid] = (idx < n) ? data[idx] : 0.0f;
     __syncthreads();
 
     for (int s = blockDim.x / 2; s > 0; s >>= 1) {
@@ -130,9 +130,9 @@ int main()
 
     // 5. Benchmark: compare IPC access vs copy-through-CPU
     // IPC path: just read GPU memory (already mapped)
-    double* d_sum;
-    CHECK_CUDA(cudaMalloc(&d_sum, sizeof(double)));
-    CHECK_CUDA(cudaMemset(d_sum, 0, sizeof(double)));
+    float* d_sum;
+    CHECK_CUDA(cudaMalloc(&d_sum, sizeof(float)));
+    CHECK_CUDA(cudaMemset(d_sum, 0, sizeof(float)));
 
     CHECK_CUDA(cudaEventRecord(start));
     partial_sum<<<blocks, threads>>>(d_data, d_sum, N);
@@ -147,7 +147,7 @@ int main()
     float* d_copy;
     CHECK_CUDA(cudaMallocHost(&h_buf, N * sizeof(float)));
     CHECK_CUDA(cudaMalloc(&d_copy, N * sizeof(float)));
-    CHECK_CUDA(cudaMemset(d_sum, 0, sizeof(double)));
+    CHECK_CUDA(cudaMemset(d_sum, 0, sizeof(float)));
 
     CHECK_CUDA(cudaEventRecord(start));
     CHECK_CUDA(cudaMemcpy(h_buf, d_data, N * sizeof(float), cudaMemcpyDeviceToHost));

--- a/ai-cpp-l7/cuda_ipc_producer.cu
+++ b/ai-cpp-l7/cuda_ipc_producer.cu
@@ -65,7 +65,7 @@ int main()
 
     // 3. Create a CUDA event to signal when data is ready
     cudaEvent_t event;
-    CHECK_CUDA(cudaEventCreate(&event, cudaEventInterprocess | cudaEventDisableTimingPeer));
+    CHECK_CUDA(cudaEventCreate(&event, cudaEventInterprocess | cudaEventDisableTiming));
     CHECK_CUDA(cudaEventRecord(event));
     CHECK_CUDA(cudaEventSynchronize(event));
 


### PR DESCRIPTION
## Summary
- Fixed CUDA IPC compile errors (`cudaEventDisableTiming`, `atomicAdd` float)
- Reverted Dockerfile to `ubuntu:22.04` base (preserves Docker layer cache)
- Added `Dockerfile.gpu` for local GPU testing (extends base with CUDA + PyTorch)
- Updated L7 README with real benchmark numbers from RTX 3060

## Test results (RTX 3060 Laptop GPU)
- All 35 L7 GPU tests pass (previously 7 skipped)
- cuda_basics: **30.2x GPU speedup** over CPU (4M element vector add)
- CUDA IPC: **15.1x speedup** over copy-through-CPU (4MB, direct GPU memory sharing)
- GPU verification: PASS (0 mismatches across 1M elements)